### PR TITLE
Test data fetching from heights

### DIFF
--- a/smartmet-plugin-wfs.spec
+++ b/smartmet-plugin-wfs.spec
@@ -89,6 +89,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %changelog
 * Upcoming
+- Add tests to test data fetching from the arbitrary heighs of hybrid forecast model.
 - Add support for data fetching from an arbitrary heigh from model topography.
 - http/https scheme selection based on X-Forwarded-Proto header; STU-5084
 

--- a/test/base/cnf/querydata.conf
+++ b/test/base/cnf/querydata.conf
@@ -7,6 +7,7 @@ producers =
         "ecmwf_eurooppa_pinta",
         "ecmwf_maailma_piste",
         "ecmwf_skandinavia_painepinta",
+        "harmonie_scandinavia_hybrid",
         "climate_tmax",
 	"tosummertime",
 	"towintertime"
@@ -90,4 +91,13 @@ climate_tmax:
         directory               = "../../../../data/climate";
         pattern                 = "tmax.sqd";
         climatology             = true;
+};
+
+harmonie_scandinavia_hybrid:
+{
+        directory               = "../../../../data/harmonie";
+        pattern                 = ".*_harmonie_hybrid-cropped\.sqd$";
+        type                    = "grid";
+        leveltype               = "model";
+        number_to_keep          = 3;
 };

--- a/test/base/output/DescribeStoredQueries/all.xml.post
+++ b/test/base/output/DescribeStoredQueries/all.xml.post
@@ -67,7 +67,7 @@
       </Abstract>
     </Parameter>
     
-    <Parameter name="latlons" type="double">
+    <Parameter name="latlons" type="doubleList">
       <Title>The list of sites for which to provide forecast</Title>
       <Abstract>
       The list of sites for which to provide forecast
@@ -99,6 +99,20 @@
       <Title>Time zone</Title>
       <Abstract>
       Time zone
+      </Abstract>
+    </Parameter>
+    
+    <Parameter name="models" type="NameList">
+      <Title>Forecast model list</Title>
+      <Abstract>
+      Forecast model list
+      </Abstract>
+    </Parameter>
+    
+    <Parameter name="heights" type="doubleList">
+      <Title>The list of heights for which to provide forecast</Title>
+      <Abstract>
+      The list of heights for which to provide forecast
       </Abstract>
     </Parameter>
     

--- a/test/base/output/DescribeStoredQueries/single.xml.post
+++ b/test/base/output/DescribeStoredQueries/single.xml.post
@@ -67,7 +67,7 @@
       </Abstract>
     </Parameter>
     
-    <Parameter name="latlons" type="double">
+    <Parameter name="latlons" type="doubleList">
       <Title>The list of sites for which to provide forecast</Title>
       <Abstract>
       The list of sites for which to provide forecast
@@ -99,6 +99,20 @@
       <Title>Time zone</Title>
       <Abstract>
       Time zone
+      </Abstract>
+    </Parameter>
+    
+    <Parameter name="models" type="NameList">
+      <Title>Forecast model list</Title>
+      <Abstract>
+      Forecast model list
+      </Abstract>
+    </Parameter>
+    
+    <Parameter name="heights" type="doubleList">
+      <Title>The list of heights for which to provide forecast</Title>
+      <Abstract>
+      The list of heights for which to provide forecast
       </Abstract>
     </Parameter>
     

--- a/test/base/output/DescribeStoredQueries/two.xml.post
+++ b/test/base/output/DescribeStoredQueries/two.xml.post
@@ -67,7 +67,7 @@
       </Abstract>
     </Parameter>
     
-    <Parameter name="latlons" type="double">
+    <Parameter name="latlons" type="doubleList">
       <Title>The list of sites for which to provide forecast</Title>
       <Abstract>
       The list of sites for which to provide forecast
@@ -99,6 +99,20 @@
       <Title>Time zone</Title>
       <Abstract>
       Time zone
+      </Abstract>
+    </Parameter>
+    
+    <Parameter name="models" type="NameList">
+      <Title>Forecast model list</Title>
+      <Abstract>
+      Forecast model list
+      </Abstract>
+    </Parameter>
+    
+    <Parameter name="heights" type="doubleList">
+      <Title>The list of heights for which to provide forecast</Title>
+      <Abstract>
+      The list of heights for which to provide forecast
       </Abstract>
     </Parameter>
     

--- a/test/base/output/GetFeature/forecast/simple_latlon_and_height_specified.xml.post
+++ b/test/base/output/GetFeature/forecast/simple_latlon_and_height_specified.xml.post
@@ -1,0 +1,108 @@
+Global data object:
+
+   fmi_apikey = "foobar";
+   fmi_apikey_prefix = "/fmi-apikey/";
+   groups = [
+              {
+                'dataOriginTime' : "2017-05-11T00:00:00Z",
+                'featureId' : "WFS-uC5Z9raR7bmDcmA0zMST60K80maJTowrEbfyy48PPpUy8.kLSxZc.ndU07ctqH.FKsYIZzGx8udaoWjp04Ol6_v37rt_DLuz6ea7dl6L8mXMvx8ua.LQpx17Be3aMHLOy7slTTty2of4UqxwxqODNp3ZJ2XDyy8.lbDs05JDMz5d.nJzrMbM27Bs3dGvL577.WS_v7ZeXflp6YcWzLE2NmXtl2SMunPo6c6Ci1STT_LAoQKY5QGlsy9suyp54ZamZs348OzLWpm0340ld16ZnDW24fETTz6Yd2PLStXQgNbbp589O7PUy.OlY27DuZW3fky7K9tGHlt37tOW_zx4d2TTuw9tOG_o84uWnIyuGHlh21rVMu3hl5YenXllbnPpv5ZcnHrl5eb.nJWxG38suPDz6VMvPo0Omnbltb92WsarUhg-",
+                'groupId' : "1-1",
+                'metadata' : {
+                               'boundingBox' : {
+                                                 'lowerLeft' : {
+                                                                 'lat' : 59.9827196409,
+                                                                 'lon' : 24.90804492
+                                                               },
+                                                 'lowerRight' : {
+                                                                  'lat' : 59.942555365,
+                                                                  'lon' : 25.8894911496
+                                                                },
+                                                 'upperLeft' : {
+                                                                 'lat' : 61.0586102407,
+                                                                 'lon' : 25.0732394668
+                                                               },
+                                                 'upperRight' : {
+                                                                  'lat' : 61.0170996051,
+                                                                  'lon' : 26.087353378
+                                                                }
+                                               }
+                             },
+                'paramList' : [
+                                {
+                                  'featureId' : "WFS-uC5Z9raR7bmDcmA0zMST60K80maJTowrEbfyy48PPpUy8.kLSxZc.ndU07ctqH.FKsYIZzGx8udaoWjp04Ol6_v37rt_DLuz6ea7dl6L8mXMvx8ua.LQpx17Be3aMHLOy7slTTty2of4UqxwxqODNp3ZJ2XDyy8.lbDs05JDMz5d.nJzrMbM27Bs3dGvL577.WS_v7ZeXflp6YcWzLE2NmXtl2SMunPo6c6Ci1STT_LAoQKY5QGlsy9suyp54ZamZs348OzLWpm0340ld16ZnDW24fETTz6Yd2PLStXQgNbbp589O7PUy.OlY27DuZW3fky7K9tGHlt37tOW_zx4d2TTuw9tOG_o84uWnIyuGHlh21rVMu3hl5YenXllbnPpv5ZcnHrl5eb.nJWxG38suPDz6VMvPo0Omnbltb92WsarUhg-",
+                                  'name' : "Temperature"
+                                }
+                              ],
+                'phenomenonEndTime' : "2017-05-12T03:00:00Z",
+                'phenomenonStartTime' : "2017-05-12T02:00:00Z",
+                'producerName' : "harmonie_scandinavia_hybrid",
+                'resultTime' : "2017-05-11T00:00:00Z",
+                'returnArray' : [
+                                  {
+                                    'data' : [
+                                               "-1.2"
+                                             ],
+                                    'elev' : "12.3457",
+                                    'epochTime' : 1494554400,
+                                    'epochTimeStr' : "2017-05-12T02:00:00Z",
+                                    'x' : "60.37752",
+                                    'y' : "25.26906"
+                                  },
+                                  {
+                                    'data' : [
+                                               "-1.3"
+                                             ],
+                                    'elev' : "12.3457",
+                                    'epochTime' : 1494558000,
+                                    'epochTimeStr' : "2017-05-12T03:00:00Z",
+                                    'x' : "60.37752",
+                                    'y' : "25.26906"
+                                  },
+                                  {
+                                    'data' : [
+                                               "-1.2"
+                                             ],
+                                    'elev' : "25",
+                                    'epochTime' : 1494554400,
+                                    'epochTimeStr' : "2017-05-12T02:00:00Z",
+                                    'x' : "60.37752",
+                                    'y' : "25.26906"
+                                  },
+                                  {
+                                    'data' : [
+                                               "-1.3"
+                                             ],
+                                    'elev' : "25",
+                                    'epochTime' : 1494558000,
+                                    'epochTimeStr' : "2017-05-12T03:00:00Z",
+                                    'x' : "60.37752",
+                                    'y' : "25.26906"
+                                  }
+                                ],
+                'stationList' : [
+                                  {
+                                    'country' : "Finland",
+                                    'elev' : "16",
+                                    'geoid' : "637067",
+                                    'iso2' : "FI",
+                                    'localtz' : "Europe\/Helsinki",
+                                    'name' : "Sipoo",
+                                    'region' : "Finland",
+                                    'x' : "60.37752",
+                                    'y' : "25.26906"
+                                  }
+                                ]
+              }
+            ];
+   hostname = "beta.fmi.fi";
+   language = "eng";
+   numMatched = 1;
+   numParam = 1;
+   numReturned = 1;
+   protocol = "http://";
+   responseTimestamp = "2012-12-12T12:12:12Z";
+   srsDim = 3;
+   srsEpochDim = 4;
+   srsEpochName = "http:\/\/xml.fmi.fi\/gml\/crs\/compoundCRS.php?crs=7409&amp;time=unixtime";
+   srsName = "http:\/\/www.opengis.net\/def\/crs\/EPSG\/0\/7409"
+ 

--- a/test/base/output/GetFeature/forecast/simple_place_and_height_specified.xml.post
+++ b/test/base/output/GetFeature/forecast/simple_place_and_height_specified.xml.post
@@ -1,0 +1,108 @@
+Global data object:
+
+   fmi_apikey = "foobar";
+   fmi_apikey_prefix = "/fmi-apikey/";
+   groups = [
+              {
+                'dataOriginTime' : "2017-05-11T00:00:00Z",
+                'featureId' : "WFS-uC5Z9raR7bmDcmA0zMST60K80maJTowrEbfyy48PPpUy8.kLSxZc.ndU07ctqH.FKsYIZzGx8udaoWjp04Ol6_v37rt_DLuz6ea7dl6L8mXMvx8ua.LQpx17Be3aMHLOy7slTTty2of4UqxwxqODNp3ZJ2XDyy8.lbDs05JDMz5d.nJzrMbM27Bs3dGvL577.WS_v7ZeXflp6YcWzLE2NmXtl2SMunPo6c6Ci1STT_LAoQKY5QGlsy9suyp54ZamZs348OzLWpm0340ld16ZnDW24fETTz6Yd2PLStXQgNbbp589O7PUy.OlY27DuZW3fky7K9tGHlt37tOW_zx4d2TTuw9tOG_o84uWnIyuGHlh21rVMu3hl5YenXllbnPpv5ZcnHrl5eb.nJWxG38suPDz6VMvPo0Omnbltb92WsarUhg-",
+                'groupId' : "1-1",
+                'metadata' : {
+                               'boundingBox' : {
+                                                 'lowerLeft' : {
+                                                                 'lat' : 59.9827196409,
+                                                                 'lon' : 24.90804492
+                                                               },
+                                                 'lowerRight' : {
+                                                                  'lat' : 59.942555365,
+                                                                  'lon' : 25.8894911496
+                                                                },
+                                                 'upperLeft' : {
+                                                                 'lat' : 61.0586102407,
+                                                                 'lon' : 25.0732394668
+                                                               },
+                                                 'upperRight' : {
+                                                                  'lat' : 61.0170996051,
+                                                                  'lon' : 26.087353378
+                                                                }
+                                               }
+                             },
+                'paramList' : [
+                                {
+                                  'featureId' : "WFS-uC5Z9raR7bmDcmA0zMST60K80maJTowrEbfyy48PPpUy8.kLSxZc.ndU07ctqH.FKsYIZzGx8udaoWjp04Ol6_v37rt_DLuz6ea7dl6L8mXMvx8ua.LQpx17Be3aMHLOy7slTTty2of4UqxwxqODNp3ZJ2XDyy8.lbDs05JDMz5d.nJzrMbM27Bs3dGvL577.WS_v7ZeXflp6YcWzLE2NmXtl2SMunPo6c6Ci1STT_LAoQKY5QGlsy9suyp54ZamZs348OzLWpm0340ld16ZnDW24fETTz6Yd2PLStXQgNbbp589O7PUy.OlY27DuZW3fky7K9tGHlt37tOW_zx4d2TTuw9tOG_o84uWnIyuGHlh21rVMu3hl5YenXllbnPpv5ZcnHrl5eb.nJWxG38suPDz6VMvPo0Omnbltb92WsarUhg-",
+                                  'name' : "Temperature"
+                                }
+                              ],
+                'phenomenonEndTime' : "2017-05-12T03:00:00Z",
+                'phenomenonStartTime' : "2017-05-12T02:00:00Z",
+                'producerName' : "harmonie_scandinavia_hybrid",
+                'resultTime' : "2017-05-11T00:00:00Z",
+                'returnArray' : [
+                                  {
+                                    'data' : [
+                                               "-1.2"
+                                             ],
+                                    'elev' : "12.3457",
+                                    'epochTime' : 1494554400,
+                                    'epochTimeStr' : "2017-05-12T02:00:00Z",
+                                    'x' : "60.37752",
+                                    'y' : "25.26906"
+                                  },
+                                  {
+                                    'data' : [
+                                               "-1.3"
+                                             ],
+                                    'elev' : "12.3457",
+                                    'epochTime' : 1494558000,
+                                    'epochTimeStr' : "2017-05-12T03:00:00Z",
+                                    'x' : "60.37752",
+                                    'y' : "25.26906"
+                                  },
+                                  {
+                                    'data' : [
+                                               "-1.2"
+                                             ],
+                                    'elev' : "25",
+                                    'epochTime' : 1494554400,
+                                    'epochTimeStr' : "2017-05-12T02:00:00Z",
+                                    'x' : "60.37752",
+                                    'y' : "25.26906"
+                                  },
+                                  {
+                                    'data' : [
+                                               "-1.3"
+                                             ],
+                                    'elev' : "25",
+                                    'epochTime' : 1494558000,
+                                    'epochTimeStr' : "2017-05-12T03:00:00Z",
+                                    'x' : "60.37752",
+                                    'y' : "25.26906"
+                                  }
+                                ],
+                'stationList' : [
+                                  {
+                                    'country' : "Finland",
+                                    'elev' : "16",
+                                    'geoid' : "637067",
+                                    'iso2' : "FI",
+                                    'localtz' : "Europe\/Helsinki",
+                                    'name' : "Sipoo",
+                                    'region' : "Finland",
+                                    'x' : "60.37752",
+                                    'y' : "25.26906"
+                                  }
+                                ]
+              }
+            ];
+   hostname = "beta.fmi.fi";
+   language = "eng";
+   numMatched = 1;
+   numParam = 1;
+   numReturned = 1;
+   protocol = "http://";
+   responseTimestamp = "2012-12-12T12:12:12Z";
+   srsDim = 3;
+   srsEpochDim = 4;
+   srsEpochName = "http:\/\/xml.fmi.fi\/gml\/crs\/compoundCRS.php?crs=7409&amp;time=unixtime";
+   srsName = "http:\/\/www.opengis.net\/def\/crs\/EPSG\/0\/7409"
+ 

--- a/test/base/stored_queries/ForecastTest.conf
+++ b/test/base/stored_queries/ForecastTest.conf
@@ -85,7 +85,7 @@ parameters:
                 name = "latlons";
                 title = { eng = "The list of sites for which to provide forecast"; };
                 abstract = { eng = "The list of sites for which to provide forecast"; };
-                xmlType = "double";
+                xmlType = "doubleList";
                 type = "double[2]";
                 minOccurs = 0;
                 maxOccurs = 98;
@@ -123,12 +123,33 @@ parameters:
                 abstract = { eng = "Time zone"; };
                 xmlType = "string";
                 type = "string";
+        },
+
+        {
+                name = "models";
+                title = { eng = "Forecast model list"; };
+                abstract = { eng = "Forecast model list"; };
+                xmlType = "NameList";
+                type = "string[1..9]";
+                minOccurs = 0;
+                maxOccurs = 1;
+        },
+
+        {
+                name = "heights";
+                title = { eng = "The list of heights for which to provide forecast"; };
+                abstract = { eng = "The list of heights for which to provide forecast"; };
+                xmlType = "doubleList";
+                type = "double[1..99]";
+                minOccurs = 0;
+                maxOccurs = 1;
         }
 );
 
 named_params:
 (
         {name:"defaultMeteoParam"; def=["Temperature", "pressure", "WindSpeedMS","WindDirection","Precipitation1h"];},
+        {name:"defaultModels"; def=["hirlam_eurooppa_pinta", "pal_skandinavia"];},
         {name:"empty_array"; def=[];},
         {name:"empty_val"; def="${}";}
 );
@@ -143,8 +164,8 @@ handler_params:
         beginTime = "${begin : now}";
         endTime = "${end : after 24 hours}";
         timeStep = "${timestep}";
-        model = ["hirlam_eurooppa_pinta", "pal_skandinavia"];
-        levelHeights = [];
+        model = ["${models > defaultModels}"];
+        levelHeights = ["${heights}"];
         level = [];
         levelType = "";
         param = ["${parameter > defaultMeteoParam}"];

--- a/test/base/xml/GetFeature/forecast/simple_latlon_and_height_specified.xml
+++ b/test/base/xml/GetFeature/forecast/simple_latlon_and_height_specified.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wfs:GetFeature
+         service="WFS"
+         version="2.0.0"
+         xmlns:wfs="http://www.opengis.net/wfs/2.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd">
+   <wfs:StoredQuery id="ForecastTest">
+     <wfs:Parameter name="begin">2017-05-12T02:00:00Z</wfs:Parameter>
+     <wfs:Parameter name="end">2017-05-12T03:00:00Z</wfs:Parameter>
+     <wfs:Parameter name="latlons">60.37752 25.26906</wfs:Parameter>
+     <wfs:Parameter name="parameter">Temperature</wfs:Parameter>
+     <wfs:Parameter name="models">harmonie_scandinavia_hybrid</wfs:Parameter>
+     <wfs:Parameter name="heights">12.34567890 25</wfs:Parameter>
+     <wfs:Parameter name="crs">http://www.opengis.net/def/crs/EPSG/0/7409</wfs:Parameter>
+   </wfs:StoredQuery>
+</wfs:GetFeature>

--- a/test/base/xml/GetFeature/forecast/simple_place_and_height_specified.xml
+++ b/test/base/xml/GetFeature/forecast/simple_place_and_height_specified.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wfs:GetFeature
+         service="WFS"
+         version="2.0.0"
+         xmlns:wfs="http://www.opengis.net/wfs/2.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd">
+   <wfs:StoredQuery id="ForecastTest">
+     <wfs:Parameter name="begin">2017-05-12T02:00:00Z</wfs:Parameter>
+     <wfs:Parameter name="end">2017-05-12T03:00:00Z</wfs:Parameter>
+     <wfs:Parameter name="place">Sipoo</wfs:Parameter>
+     <wfs:Parameter name="parameter">Temperature</wfs:Parameter>
+     <wfs:Parameter name="models">harmonie_scandinavia_hybrid</wfs:Parameter>
+     <wfs:Parameter name="heights">12.34567890 25</wfs:Parameter>
+     <wfs:Parameter name="crs">http://www.opengis.net/def/crs/EPSG/0/7409</wfs:Parameter>
+   </wfs:StoredQuery>
+</wfs:GetFeature>


### PR DESCRIPTION
I added to ForecastTest stored query "heights" and "models" request parameters so that it can be used for fetching hybrid data. The change required some result updates to DescribeStoredQuery responses. 

Finally I added couple regression tests to test that heights parameter works properly. The regression test results do not contain correct response elevations for the requested heights because Querydata Engine does not return heights from the mean sea level at the moment. The height are calculated from the surface of a model used behind a stored query.

The changes requires that the pull request https://github.com/fmidev/smartmet-test-data/pull/1 is accepted into the master to work properly.