### PR TITLE
Add missing joinability check for an option thread to avoid crash

### DIFF
--- a/smartmet-plugin-wfs.spec
+++ b/smartmet-plugin-wfs.spec
@@ -88,6 +88,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_sysconfdir}/smartmet/plugins/wfs/XMLSchemas.cache
 
 %changelog
+* Upcoming
+- Check joinability of an option thread in StoredEnvMonitoringFacilityQueryHandler.
+
 * Tue May 23 2017 Mika Heiskanen <mika.heiskanen@fmi.fi> - 17.5.23-1.fmi
 - Add tests to test data fetching from arbitrary heights of hybrid forecast model.
 - Add support for data fetching from an arbitrary height from model topography.

--- a/source/stored_queries/StoredEnvMonitoringFacilityQueryHandler.cpp
+++ b/source/stored_queries/StoredEnvMonitoringFacilityQueryHandler.cpp
@@ -179,7 +179,8 @@ void bw::StoredEnvMonitoringFacilityQueryHandler::query(const StoredQuery &query
                     boost::ref(params),
                     boost::ref(validStations)));
 
-    thread1.join();
+    if (thread1.joinable())
+      thread1.join();
     thread2.join();
     thread3.join();
 


### PR DESCRIPTION
The change fixes an crashing problem when value of showObservingCapability stored query handler parameter is false. Crashing happens when a thread is not joinable and it is still tried to join.