### PR TITLE
Replace suggest methods with nameSearch.

### DIFF
--- a/smartmet-plugin-wfs.spec
+++ b/smartmet-plugin-wfs.spec
@@ -88,6 +88,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_sysconfdir}/smartmet/plugins/wfs/XMLSchemas.cache
 
 %changelog
+* Upcoming
+- Replace few suggest methods with nameSearch to avoid server crash.
+
 * Wed May 24 2017 Mika Heiskanen <mika.heiskanen@fmi.fi> - 17.5.24-1.fmi
 - Check joinability of an option thread in StoredEnvMonitoringFacilityQueryHandler.
 

--- a/source/SupportsLocationParameters.cpp
+++ b/source/SupportsLocationParameters.cpp
@@ -267,6 +267,13 @@ void bw::SupportsLocationParameters::get_wmos(
 {
   try
   {
+    Locus::QueryOptions opts;
+    opts.SetCountries("all");
+    opts.SetSearchVariants(true);
+    opts.SetLanguage("wmo");
+    opts.SetFeatures("SYNOP,STUK");
+    opts.SetResultLimit(1);
+
     std::vector<int64_t> ids;
     param.get<int64_t>(P_WMOS, std::back_inserter(ids));
     BOOST_FOREACH (int64_t id, ids)
@@ -281,7 +288,7 @@ void bw::SupportsLocationParameters::get_wmos(
       else
       {
         std::string id_s = boost::lexical_cast<std::string>(id);
-        SmartMet::Spine::LocationList locList = geo_engine->suggest(id_s, "wmo");
+        SmartMet::Spine::LocationList locList = geo_engine->nameSearch(opts, id_s);
         if (include_wmos and locList.empty())
         {
           SmartMet::Spine::Exception exception(BCP, "Unknown 'wmoid' value!");

--- a/source/stored_queries/StoredEnvMonitoringFacilityQueryHandler.cpp
+++ b/source/stored_queries/StoredEnvMonitoringFacilityQueryHandler.cpp
@@ -219,6 +219,13 @@ void bw::StoredEnvMonitoringFacilityQueryHandler::query(const StoredQuery &query
       std::string lang = language;
       SupportsLocationParameters::engOrFinToEnOrFi(lang);
 
+      Locus::QueryOptions opts;
+      opts.SetCountries("all");
+      opts.SetSearchVariants(true);
+      opts.SetLanguage("fmisid");
+      opts.SetFeatures("SYNOP,STUK");
+      opts.SetResultLimit(1);
+
       for (bw::StoredEnvMonitoringFacilityQueryHandler::StationDataMap::iterator vsIt =
                validStations.begin();
            vsIt != validStations.end();
@@ -256,7 +263,7 @@ void bw::StoredEnvMonitoringFacilityQueryHandler::query(const StoredQuery &query
         std::string countryName;
 
         // Data from Geonames
-        SmartMet::Spine::LocationList locList = m_geoEngine->suggest((*vsIt).first, "fmisid");
+        SmartMet::Spine::LocationList locList = m_geoEngine->nameSearch(opts, (*vsIt).first);
         if (not locList.empty())
         {
           SmartMet::Spine::LocationPtr stationLocPtr = locList.front();


### PR DESCRIPTION
On server startup Geonames Engine keeps reading data from database after
it is initialized. If a request is passed to the engeine before the read
is completely done server crash.

The nameSearch works quite similarly with suggest but the result is not
ordered so that the first one is an exact match if found.