### PR TITLE
Poll stored query configuration changes and update the handlers

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -49,6 +49,7 @@ class Config : private boost::noncopyable, public SmartMet::Spine::ConfigBase
   bool getValidateXmlOutput() const { return validate_output; }
   bool getEnableDemoQueries() const { return enable_demo_queries; }
   bool getEnableTestQueries() const { return enable_test_queries; }
+  bool getEnableConfigurationPolling() const { return enable_configuration_polling; }
   bool getSQRestrictions() const { return sq_restrictions; }
   int getDefaultExpiresSeconds() const { return default_expires_seconds; }
   const Fmi::TemplateDirectory& get_template_directory() const { return *template_directory; }
@@ -58,6 +59,7 @@ class Config : private boost::noncopyable, public SmartMet::Spine::ConfigBase
   inline int getCacheTimeConstant() const { return cache_time_constant; }
   std::vector<boost::shared_ptr<WfsFeatureDef> > read_features_config(
       SmartMet::Engine::Gis::CRSRegistry& theCRSRegistry);
+
   void read_typename_config(std::map<std::string, std::string>& typename_storedqry);
 
  private:
@@ -74,6 +76,7 @@ class Config : private boost::noncopyable, public SmartMet::Spine::ConfigBase
   bool validate_output;
   bool enable_demo_queries;
   bool enable_test_queries;
+  bool enable_configuration_polling;
   bool sq_restrictions;
 
 };  // class Config

--- a/include/Plugin.h
+++ b/include/Plugin.h
@@ -32,6 +32,7 @@
 #include <list>
 #include <map>
 #include <string>
+#include <thread>
 
 namespace SmartMet
 {
@@ -125,6 +126,8 @@ class Plugin : public SmartMetPlugin, virtual private boost::noncopyable, privat
  private:
   boost::shared_ptr<pqxx::connection> create_geoserver_db_conn() const;
 
+  void updateLoop();
+
  private:
   const std::string itsModuleName;
 
@@ -140,6 +143,12 @@ class Plugin : public SmartMetPlugin, virtual private boost::noncopyable, privat
   SmartMet::Spine::Reactor* itsReactor;
 
   const char* itsConfig;
+
+  bool itsShutdownRequested;
+
+  int itsUpdateLoopThreadCount;
+
+  std::unique_ptr<std::thread> itsUpdateLoopThread;
 
 };  // class Plugin
 

--- a/include/PluginData.h
+++ b/include/PluginData.h
@@ -90,6 +90,8 @@ class PluginData : public boost::noncopyable
   inline WfsCapabilities& get_capabilities() { return *wfs_capabilities; }
   inline const WfsCapabilities& get_capabilities() const { return *wfs_capabilities; }
 
+  void updateStoredQueryMap();
+
  private:
   void create_template_formatters();
   void create_xml_parser();

--- a/include/PluginData.h
+++ b/include/PluginData.h
@@ -90,7 +90,7 @@ class PluginData : public boost::noncopyable
   inline WfsCapabilities& get_capabilities() { return *wfs_capabilities; }
   inline const WfsCapabilities& get_capabilities() const { return *wfs_capabilities; }
 
-  void updateStoredQueryMap();
+  void updateStoredQueryMap(Spine::Reactor* theReactor);
 
  private:
   void create_template_formatters();

--- a/include/StoredQueryConfig.h
+++ b/include/StoredQueryConfig.h
@@ -158,11 +158,27 @@ class StoredQueryConfig : public SmartMet::Spine::ConfigBase
 
   void warn_about_unused_params(const StoredQueryHandlerBase* handler = NULL);
 
+  /**
+   *  @brief Get last write time of the stored query configuration file.
+   *  If the file is removed the time stored to an object is returned.
+   *  @return The last write time if file.
+   */
+  std::time_t config_write_time() const;
+
+  /**
+   *  @brief Test if the stored query configuration file is changed.
+   *  @retval true Last write time has changed.
+   *  @retval false Last write time has not changed.
+   */
+  bool last_write_time_changed() const;
+
  private:
   void parse_config();
 
  private:
   std::string query_id;
+  std::time_t config_last_write_time;
+
   int expires_seconds;  ///< For the expires entity-header field. After that the response is
                         /// considered stale.
                         /**

--- a/include/StoredQueryMap.h
+++ b/include/StoredQueryMap.h
@@ -49,6 +49,8 @@ class StoredQueryMap
 
   virtual std::vector<std::string> get_return_type_names() const;
 
+  void update_handlers();
+
  private:
   void add_handler(SmartMet::Spine::Reactor* theReactor,
                    boost::shared_ptr<StoredQueryConfig> sqh_config,

--- a/include/StoredQueryMap.h
+++ b/include/StoredQueryMap.h
@@ -49,7 +49,7 @@ class StoredQueryMap
 
   virtual std::vector<std::string> get_return_type_names() const;
 
-  void update_handlers();
+  void update_handlers(Spine::Reactor* theReactor, PluginData& plugin_data);
 
  private:
   void add_handler(SmartMet::Spine::Reactor* theReactor,

--- a/source/Config.cpp
+++ b/source/Config.cpp
@@ -50,6 +50,9 @@ Config::Config(const string& configfile)
     validate_output = get_optional_config_param<bool>("validateXmlOutput", false);
     enable_demo_queries = get_optional_config_param<bool>("enableDemoQueries", false);
     enable_test_queries = get_optional_config_param<bool>("enableTestQueries", false);
+    enable_configuration_polling =
+        get_optional_config_param<bool>("enableConfigurationPolling", false);
+
     sq_restrictions = get_optional_config_param<bool>("storedQueryRestrictions", true);
 
     std::vector<std::string> xml_grammar_pool_fns;

--- a/source/Plugin.cpp
+++ b/source/Plugin.cpp
@@ -832,7 +832,7 @@ void Plugin::updateLoop()
           boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
 
         if (not itsShutdownRequested)
-          plugin_data->updateStoredQueryMap();
+          plugin_data->updateStoredQueryMap(itsReactor);
       }
       catch (...)
       {

--- a/source/Plugin.cpp
+++ b/source/Plugin.cpp
@@ -836,7 +836,7 @@ void Plugin::updateLoop()
       }
       catch (...)
       {
-        Spine::Exception exception(BCP, "Could not update storedQueries!", NULL);
+        Spine::Exception exception(BCP, "Stored query map update failed!", NULL);
         exception.printError();
       }
     }

--- a/source/Plugin.cpp
+++ b/source/Plugin.cpp
@@ -146,8 +146,9 @@ void Plugin::init()
         }
       }
 
-      // Begin the update loop
-      itsUpdateLoopThread.reset(new std::thread(std::bind(&Plugin::updateLoop, this)));
+      // Begin the update loop if enabled
+      if (plugin_data->get_config().getEnableConfigurationPolling())
+        itsUpdateLoopThread.reset(new std::thread(std::bind(&Plugin::updateLoop, this)));
     }
     catch (...)
     {

--- a/source/PluginData.cpp
+++ b/source/PluginData.cpp
@@ -73,11 +73,11 @@ bw::PluginData::~PluginData()
 {
 }
 
-void bw::PluginData::updateStoredQueryMap()
+void bw::PluginData::updateStoredQueryMap(Spine::Reactor *theReactor)
 {
   try
   {
-    stored_query_map->update_handlers();
+    stored_query_map->update_handlers(theReactor, *this);
   }
   catch (...)
   {

--- a/source/PluginData.cpp
+++ b/source/PluginData.cpp
@@ -73,6 +73,18 @@ bw::PluginData::~PluginData()
 {
 }
 
+void bw::PluginData::updateStoredQueryMap()
+{
+  try
+  {
+    stored_query_map->update_handlers();
+  }
+  catch (...)
+  {
+    throw Spine::Exception(BCP, "Stored query handlers update failed!", NULL);
+  }
+}
+
 boost::posix_time::ptime bw::PluginData::get_time_stamp() const
 {
   try

--- a/source/StoredQueryMap.cpp
+++ b/source/StoredQueryMap.cpp
@@ -403,3 +403,8 @@ void bw::StoredQueryMap::add_handler_thread_proc(SmartMet::Spine::Reactor* theRe
     throw SmartMet::Spine::Exception(BCP, "Operation failed!", NULL);
   }
 }
+
+void bw::StoredQueryMap::update_handlers()
+{
+
+}


### PR DESCRIPTION
The changes in the branch gives a possibility to change stored query configurations on runtime.

During startup of server a thread is created for use of polling stored query configuration changes. Last change time of each configuration file are checked every 5 seconds. New handler object replaces the old one if the timestamp of file in question is changed.

Stored query id is not allowed to be changed on runtime. It always requires a server restart.
If a stored query configuration is deleted, the handler created from the configuration is not removed. If some stored query is not wanted to be in use, disabled setting can be used. 