### PR TITLE
Fix coordinate order of set_2D_coord function inputs.

### DIFF
--- a/source/stored_queries/StoredSoundingQueryHandler.cpp
+++ b/source/stored_queries/StoredSoundingQueryHandler.cpp
@@ -394,7 +394,7 @@ void StoredSoundingQueryHandler::query(const StoredQuery& query,
                 stationLatitude + dataContainer->castTo<double>(dataLatitudeIt, 6);
             const double levelLon =
                 stationLongitude + dataContainer->castTo<double>(dataLongitudeIt, 6);
-            set_2D_coord(transformation, levelLon, levelLat, row);
+            set_2D_coord(transformation, levelLat, levelLon, row);
             uint32_t significance = dataContainer->castTo<uint32_t>(dataSignificanceIt, 0);
             row["significance"] = significance;
             std::bitset<18> sBitset(significance);


### PR DESCRIPTION
Source CRS of the coordinate transformation is using coordinate order latitude-longitude. The input values must be given in that order. In the handler, there is an other call of set_2D_coord function where the input values are in the right order.