### PR TITLE
Shutdown updateloop correctly

### DIFF
--- a/include/Plugin.h
+++ b/include/Plugin.h
@@ -147,11 +147,7 @@ class Plugin : public SmartMetPlugin, virtual private boost::noncopyable, privat
   boost::atomic<bool> itsShutdownRequested;
   boost::atomic<int> itsUpdateLoopThreadCount;
 
-#ifdef TODO_CLEAN_CRASH_UNIQUE_PTR
   std::unique_ptr<std::thread> itsUpdateLoopThread;
-#else
-  std::thread* itsUpdateLoopThread;
-#endif
 
 };  // class Plugin
 

--- a/source/Plugin.cpp
+++ b/source/Plugin.cpp
@@ -827,7 +827,7 @@ void Plugin::updateLoop()
   try
   {
     itsUpdateLoopThreadCount++;
-    while (not itsShutdownRequested)
+    while (not(itsShutdownRequested or isShutdownRequested()))
     {
       try
       {

--- a/source/Plugin.cpp
+++ b/source/Plugin.cpp
@@ -185,6 +185,9 @@ void Plugin::shutdown()
 
     while (itsUpdateLoopThreadCount > 0)
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    if (itsUpdateLoopThread and itsUpdateLoopThread->joinable())
+      itsUpdateLoopThread->join();
   }
   catch (...)
   {

--- a/source/Plugin.cpp
+++ b/source/Plugin.cpp
@@ -148,11 +148,7 @@ void Plugin::init()
 
       // Begin the update loop if enabled
       if (plugin_data->get_config().getEnableConfigurationPolling())
-#ifdef TODO_CLEAN_CRASH_UNIQUE_PTR
         itsUpdateLoopThread.reset(new std::thread(std::bind(&Plugin::updateLoop, this)));
-#else
-        itsUpdateLoopThread = new std::thread(std::bind(&Plugin::updateLoop, this));
-#endif
     }
     catch (...)
     {
@@ -201,7 +197,9 @@ void Plugin::shutdown()
  */
 // ----------------------------------------------------------------------
 
-Plugin::~Plugin() {}
+Plugin::~Plugin()
+{
+}
 // ----------------------------------------------------------------------
 /*!
  * \brief Return the plugin name

--- a/source/stored_queries/StoredForecastQueryHandler.cpp
+++ b/source/stored_queries/StoredForecastQueryHandler.cpp
@@ -456,7 +456,7 @@ boost::shared_ptr<SmartMet::Spine::Table> bw::StoredForecastQueryHandler::extrac
       if (not query.origin_time)
       {
         // With multifile data q_engine->get() origintime must not be set/locked
- 
+
         query.origin_time.reset(new pt::ptime(q->originTime()));
 
         if (not q_engine->getProducerConfig(producer).ismultifile)


### PR DESCRIPTION
The branch fix a crash happening during shutdown of the plugin when configuration polling is set on.

The previous TODO_CLEAN_CRASH_UNIQUE_PTR fix didn't fix the problem. The problem was that
the thread used for configuration polling wasn't deleted correctly because its destructor doesn't
join ongoing job or clean things. 