### PR TITLE
Use wml2:qualifier element to view quality codes insted of wml2:quality

### DIFF
--- a/cnf/templates/include/results_obs_timevaluepair.template
+++ b/cnf/templates/include/results_obs_timevaluepair.template
@@ -3,10 +3,15 @@
                         <wml2:point>
                             <wml2:MeasurementTVP> 
                                       <wml2:time><TMPL_var row.epochTimeStr></wml2:time>
-				      <wml2:value><TMPL_var dataIt.value></wml2:value><TMPL_if (DEFINED(group.qualityInfo) && DEFINED(dataIt.qcValue))>
+				      <wml2:value><TMPL_var dataIt.value></wml2:value><TMPL_if (DEFINED(obsParam.isQCParameter) || (DEFINED(dataIt.qcValue) && DEFINED(group.qualityInfo)))>
                                       <wml2:metadata>
                                         <wml2:TVPMeasurementMetadata>
-                                          <wml2:quality xlink:title="qc-<TMPL_var dataIt.qcValue>" xlink:href="<TMPL_var protocol><TMPL_var hostname><TMPL_var fmi_apikey_prefix><TMPL_var fmi_apikey>/meta?qualitycode=<TMPL_var dataIt.qcValue>&amp;language=eng&amp;"/>
+                                          <wml2:qualifier>
+                                            <swe:Category>
+                                              <swe:codeSpace xlink:title="Quality codes" xlink:href="<TMPL_var protocol><TMPL_var hostname><TMPL_var fmi_apikey_prefix><TMPL_var fmi_apikey>/meta?qualitycode=&amp;language=<TMPL_var language>&amp;"/><TMPL_if !DEFINED(obsParam.isQCParameter)>
+                                              <swe:value><TMPL_var dataIt.qcValue></swe:value></TMPL_if>
+                                            </swe:Category>
+                                          </wml2:qualifier>
                                         </wml2:TVPMeasurementMetadata>
                                       </wml2:metadata></TMPL_if>
                             </wml2:MeasurementTVP>

--- a/source/stored_queries/StoredObsQueryHandler.cpp
+++ b/source/stored_queries/StoredObsQueryHandler.cpp
@@ -201,10 +201,10 @@ void StoredObsQueryHandler::query(const StoredQuery& query,
       std::vector<std::string> qc_info_param_names;
       const bool support_quality_info = SupportsQualityParameters::supportQualityInfo(params);
 
-      if (not m_support_qc_parameters)
+      auto qc_param_name_ref = SupportsQualityParameters::firstQCParameter(param_names);
+      if (not m_support_qc_parameters or not support_quality_info)
       {
         // Do not allow QC parameters if it is not enabled in stored query.
-        auto qc_param_name_ref = SupportsQualityParameters::firstQCParameter(param_names);
         if (qc_param_name_ref != param_names.end())
         {
           SmartMet::Spine::Exception exception(BCP, "Invalid parameter!");
@@ -213,13 +213,13 @@ void StoredObsQueryHandler::query(const StoredQuery& query,
           exception.addParameter(WFS_EXCEPTION_CODE, WFS_INVALID_PARAMETER_VALUE);
           throw exception;
         }
+      }
 
-        // Quality info parameter construction
-        if (support_quality_info)
-        {
-          BOOST_FOREACH (const std::string& name, param_names)
-            qc_info_param_names.push_back("qc_" + name);
-        }
+      // Quality info parameter construction if there is not any QC parameters given.
+      if (support_quality_info and qc_param_name_ref == param_names.end())
+      {
+        BOOST_FOREACH (const std::string& name, param_names)
+          qc_info_param_names.push_back("qc_" + name);
       }
 
       int first_param = 0, last_param = 0;


### PR DESCRIPTION
The wml2:quality element allows only to use predefined code range
defined in the WaterML specification. The qualifier element is more
flexible on this kind of use. The element also allows to use
swe:Category element which is used in MultipointCoverage responses.

There is also clarified the use of qualityInfo setting in handler
parameters. The setting must be turned on if quality codes is
wanted to be requested. Even if the supportQCParameters setting is turned
on, while qualityInfo is off, QC parameters are not allowed.

If the quality codes of measured values are wanted to be present in a result, one must set true value to the qualityInfo of handler parameters in stored query configuration. It adds a wml2:metadata element block after the each wml2:value element of request result. 