### PR TITLE
Arrange sounding messages to descending order using message time

### DIFF
--- a/smartmet-plugin-wfs.spec
+++ b/smartmet-plugin-wfs.spec
@@ -93,6 +93,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_sysconfdir}/smartmet/plugins/wfs/XMLSchemas.cache
 
 %changelog
+* Upcoming
+- Arrange soundings using message_time to get the latest request parameter work correctly
+
 * Mon May  7 2018 Mika Heiskanen <mika.heiskanen@fmi.fi> - 18.5.7-2.fmi
 - Require newer querydata-engine so that data independent latlon parameters can be used
 

--- a/source/stored_queries/StoredSoundingQueryHandler.cpp
+++ b/source/stored_queries/StoredSoundingQueryHandler.cpp
@@ -650,6 +650,9 @@ void StoredSoundingQueryHandler::parseSoundingQuery(const RequestParameterMap& p
        ++soundingIdIt, ++stationIdIt, ++messageTimeIt, ++launchTimeIt, ++soundingEndIt)
   {
     const int32_t tmpstationId = soundingQueryResult->castTo<int32_t>(stationIdIt);
+
+    // The messages are arranged to descending order using MESSAGE_TIME.
+    // If the value of latest is true, we pick only the first radiosounding.
     if ((not latest) or (latest and latestSet.find(tmpstationId) == latestSet.end()))
     {
       const int32_t soundingId = soundingQueryResult->castTo<int32_t>(soundingIdIt);
@@ -714,6 +717,7 @@ void StoredSoundingQueryHandler::makeSoundingQuery(const RequestParameterMap& pa
       "OR_GROUP_data_end_time", "MESSAGE_TIME", "PropertyIsLessThanOrEqualTo", endTime);
 
   profileQueryParams.addOrderBy("STATION_ID", "ASC");
+  profileQueryParams.addOrderBy("MESSAGE_TIME", "DESC");
 
   // Execute query
   SmartMet::Engine::Observation::MastQuery profileQuery;


### PR DESCRIPTION
The request parameter "latest" did not work correctly because
the messages were not in descending order. So, we can request database
to arrange the result to fix the issue.