### PR TITLE
Remove cache object after expiration time period

### DIFF
--- a/source/request/GetFeature.cpp
+++ b/source/request/GetFeature.cpp
@@ -485,7 +485,8 @@ bool bw::Request::GetFeature::collect_query_responses(std::vector<std::string>& 
         {
           query_ptr->execute(result_stream, get_language());
           const std::string cache_key = query_ptr->get_cache_key();
-          query_cache.insert(cache_key, result_stream.str());
+          query_cache.insert(cache_key, result_stream.str(), cache_key);
+          query_cache.expire(cache_key);
 
           // FIXME: should we restrict caching on too large responses?
           std::ostringstream tmp;
@@ -605,7 +606,6 @@ boost::shared_ptr<bw::Request::GetFeature> bw::Request::GetFeature::create_from_
                                       typename_stored_query_map,
                                       result->queries);
     }
-
     result->fast = result->get_cached_responses();
     return result;
   }

--- a/source/request/GetPropertyValue.cpp
+++ b/source/request/GetPropertyValue.cpp
@@ -603,7 +603,8 @@ bool GetPropertyValue::collect_query_responses(std::vector<std::string>& query_r
         std::ostringstream result_stream;
         query_ptr->execute(result_stream, get_language());
         const std::string cache_key = query_ptr->get_cache_key();
-        query_cache.insert(cache_key, result_stream.str());
+        query_cache.insert(cache_key, result_stream.str(), cache_key);
+        query_cache.expire(cache_key);
 
         // FIXME: should we restrict caching on too large responses?
 


### PR DESCRIPTION
This feature was removed couple years ago because it was assumed to
cause server crashes. The bug assumed to be in Cache class of MacGyver
library but nothing has been found from the code.

The insert method inserts the cache_key and the tag (cache_key). It
also makes space for the new insertion if cache is full.
The expire method updates expiration time of the inserted tag to
current time and after that it clears the tags expired in the cache.
The insert and the expire methods are called only when cache object is
not found with Cache::find method. The find method removes the cache
object matched with the cache_key if its tag is expired.