### PR TITLE
Start using the TimedCache of MacGyver library.

### DIFF
--- a/include/Plugin.h
+++ b/include/Plugin.h
@@ -20,9 +20,9 @@
 
 #include <ctpp2/CDT.hpp>
 
-#include <macgyver/Cache.h>
 #include <macgyver/ObjectPool.h>
 #include <macgyver/TemplateFormatterMT.h>
+#include <macgyver/TimedCache.h>
 
 #include <boost/shared_ptr.hpp>
 #include <boost/thread.hpp>

--- a/include/PluginData.h
+++ b/include/PluginData.h
@@ -14,8 +14,8 @@
 #include "XmlParser.h"
 #include <boost/date_time/posix_time/ptime.hpp>
 #include <boost/shared_ptr.hpp>
-#include <macgyver/Cache.h>
 #include <macgyver/TemplateFormatterMT.h>
+#include <macgyver/TimedCache.h>
 
 namespace SmartMet
 {
@@ -25,9 +25,7 @@ namespace WFS
 {
 class StoredQueryMap;
 
-typedef Fmi::Cache::
-    Cache<std::string, std::string, Fmi::Cache::LRUEviction, std::string, Fmi::Cache::InstantExpire>
-        QueryResponseCache;
+typedef Fmi::TimedCache::Cache<std::string, std::string> QueryResponseCache;
 
 class PluginData : public boost::noncopyable
 {

--- a/include/request/GetFeature.h
+++ b/include/request/GetFeature.h
@@ -4,7 +4,7 @@
 #include "QueryBase.h"
 #include "RequestBase.h"
 #include "StandardPresentationParameters.h"
-#include <macgyver/Cache.h>
+#include <macgyver/TimedCache.h>
 #include <xercesc/dom/DOMDocument.hpp>
 
 namespace SmartMet

--- a/include/request/GetPropertyValue.h
+++ b/include/request/GetPropertyValue.h
@@ -6,7 +6,7 @@
 #include "StandardPresentationParameters.h"
 #include "StoredQueryMap.h"
 #include "XPathSnapshot.h"
-#include <macgyver/Cache.h>
+#include <macgyver/TimedCache.h>
 #include <xercesc/dom/DOMDocument.hpp>
 
 namespace SmartMet

--- a/source/Plugin.cpp
+++ b/source/Plugin.cpp
@@ -83,8 +83,9 @@ void Plugin::init()
     try
     {
       plugin_data.reset(new PluginData(itsReactor, itsConfig));
-      query_cache.reset(new QueryResponseCache(plugin_data->get_config().getCacheSize(),
-                                               plugin_data->get_config().getCacheTimeConstant()));
+      query_cache.reset(new QueryResponseCache(
+          plugin_data->get_config().getCacheSize(),
+          std::chrono::seconds(plugin_data->get_config().getCacheTimeConstant())));
       request_factory.reset(new RequestFactory(*plugin_data));
 
       if (itsReactor->getRequiredAPIVersion() != SMARTMET_API_VERSION)

--- a/source/request/GetFeature.cpp
+++ b/source/request/GetFeature.cpp
@@ -485,8 +485,7 @@ bool bw::Request::GetFeature::collect_query_responses(std::vector<std::string>& 
         {
           query_ptr->execute(result_stream, get_language());
           const std::string cache_key = query_ptr->get_cache_key();
-          query_cache.insert(cache_key, result_stream.str(), cache_key);
-          query_cache.expire(cache_key);
+          query_cache.insert(cache_key, result_stream.str());
 
           // FIXME: should we restrict caching on too large responses?
           std::ostringstream tmp;

--- a/source/request/GetPropertyValue.cpp
+++ b/source/request/GetPropertyValue.cpp
@@ -603,8 +603,7 @@ bool GetPropertyValue::collect_query_responses(std::vector<std::string>& query_r
         std::ostringstream result_stream;
         query_ptr->execute(result_stream, get_language());
         const std::string cache_key = query_ptr->get_cache_key();
-        query_cache.insert(cache_key, result_stream.str(), cache_key);
-        query_cache.expire(cache_key);
+        query_cache.insert(cache_key, result_stream.str());
 
         // FIXME: should we restrict caching on too large responses?
 


### PR DESCRIPTION
The old Cache class causing server crashes if time eviction is used.
The new Cache implements same properties as the old one. The TimedCache class is available from version 18.6.7